### PR TITLE
Pow 2

### DIFF
--- a/lib/address.cairo
+++ b/lib/address.cairo
@@ -1,31 +1,26 @@
 from starkware.cairo.common.math import assert_le, unsigned_div_rem
 from starkware.cairo.common.math_cmp import is_le
+from starkware.cairo.common.pow import pow
 
 from lib.types import Address
-from lib.pow import pow
 from lib.bitshift import bitshift_right, bitshift_left
 
 func address_words64_to_160bit{range_check_ptr}(input: Address) -> (res: felt) {
     alloc_locals;
-    let (local word_1_exponent) = pow(2, 8 * 12);
-    let (local word_2_exponent) = pow(2, 8 * 4);
 
-    let result = (input.word_1 * word_1_exponent) + (input.word_2 * word_2_exponent) + input.word_3;
+    let result = (input.word_1 * 2 ** 96) + (input.word_2 * 2 ** 32) + input.word_3;
     return (result,);
 }
 
 func address_160bit_to_words64{range_check_ptr}(input: felt) -> (res: Address) {
     alloc_locals;
 
-    let (local eigth_byte_exponent) = pow(2, 8 * 8);
-    let (local four_byte_exponent) = pow(2, 4 * 8);
-
-    let (tmp, third_word) = unsigned_div_rem(input, four_byte_exponent);
+    let (tmp, third_word) = unsigned_div_rem(input, 2 ** 32);  // 2 ** 8 * 4
 
     let third_word_max_size = 2 ** 32 - 1;
     assert_le(third_word, third_word_max_size);
 
-    let (first_word, second_word) = unsigned_div_rem(tmp, eigth_byte_exponent);
+    let (first_word, second_word) = unsigned_div_rem(tmp, 2 ** 64);  // 2 ** 8 * 8
     local res: Address = Address(first_word, second_word, third_word);
     return (res,);
 }

--- a/lib/bitset.cairo
+++ b/lib/bitset.cairo
@@ -1,4 +1,4 @@
-from lib.pow import pow
+from starkware.cairo.common.pow import pow
 from starkware.cairo.common.math import unsigned_div_rem
 
 // Argument bitset: n bits number in range(0, 2**n - 1)

--- a/lib/bitshift.cairo
+++ b/lib/bitshift.cairo
@@ -1,6 +1,6 @@
 from starkware.cairo.common.math import assert_le
 from starkware.cairo.common.math import unsigned_div_rem
-from lib.pow import pow
+from starkware.cairo.common.pow import pow
 
 func bitshift_right{range_check_ptr}(word: felt, num_bits: felt) -> (shifted: felt) {
     // verifies word fits in 64bits

--- a/lib/extract_from_rlp.cairo
+++ b/lib/extract_from_rlp.cairo
@@ -2,10 +2,10 @@ from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
 from starkware.cairo.common.math import unsigned_div_rem
 from starkware.cairo.common.math_cmp import is_le
 from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.pow import pow
 
 from lib.types import IntsSequence, RLPItem
 from lib.bitshift import bitshift_right, bitshift_left
-from lib.pow import pow
 
 func getElement{range_check_ptr}(rlp: IntsSequence, position: felt) -> (res: RLPItem) {
     alloc_locals;
@@ -242,11 +242,10 @@ func extract_data_rec{range_check_ptr}(
     }
 
     local new_word = left_part + right_part;
-    let (local divider: felt) = pow(2, 64);
 
     local range_check_ptr = range_check_ptr;
 
-    let (_, new_word_masked) = unsigned_div_rem(new_word, divider);
+    let (_, new_word_masked) = unsigned_div_rem(new_word, 2 ** 64);
 
     local range_check_ptr = range_check_ptr;
 

--- a/lib/swap_endianness.cairo
+++ b/lib/swap_endianness.cairo
@@ -3,7 +3,7 @@ from starkware.cairo.common.math import assert_le
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.math import assert_nn_le, unsigned_div_rem
 from starkware.cairo.common.math_cmp import is_in_range
-from lib.pow import pow
+from starkware.cairo.common.pow import pow
 from lib.types import IntsSequence
 
 // func swap_endianness_many_words{ range_check_ptr, bitwise_ptr : BitwiseBuiltin* }(input: IntsSequence) -> (output: IntsSequence):

--- a/lib/words64.cairo
+++ b/lib/words64.cairo
@@ -2,10 +2,10 @@ from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
 from starkware.cairo.common.math import assert_le, unsigned_div_rem
 from starkware.cairo.common.math_cmp import is_le
 from starkware.cairo.common.alloc import alloc
+from starkware.cairo.common.pow import pow
 
 from lib.bitshift import bitshift_right, bitshift_left
 from lib.types import IntsSequence
-from lib.pow import pow
 
 func extract_nibble{range_check_ptr}(word: felt, word_len_bytes: felt, position: felt) -> (
     res: felt
@@ -89,8 +89,7 @@ func to_words128_rec{range_check_ptr}(
             );
         }
     } else {
-        let (local multiplicator) = pow(2, 64);
-        local left_part = words64.element[current_word_index] * multiplicator;
+        local left_part = words64.element[current_word_index] * 2 ** 64;
         local original = words64.element[current_word_index];
         local word128 = left_part + words64.element[current_word_index + 1];
         assert acc[acc_len] = word128;

--- a/protostar.toml
+++ b/protostar.toml
@@ -1,8 +1,8 @@
 [project]
-protostar-version = "0.7.0"
+protostar-version = "0.8.1"
 lib-path = "lib"
 
-cairo-path = ["lib/cairo_contracts/src"]
+cairo-path = ["lib/cairo_contracts/src", "lib/utils", "tests"]
 
 [contracts]
 Account = ["src/external/Account.cairo"]

--- a/tests/test_bitset.cairo
+++ b/tests/test_bitset.cairo
@@ -73,6 +73,12 @@ func test_bitset{range_check_ptr}() -> () {
 }
 
 @view
+func setup_bitset_random{range_check_ptr}() -> () {
+    %{ given(random_bitset = strategy.felts()) %}
+    return ();
+}
+
+@view
 func test_bitset_random{range_check_ptr}(random_bitset: felt) -> () {
     if (is_in_range(random_bitset, 1, 2 ** 16 - 1) == 0) {
         %{ reject() %}

--- a/tests/test_ints_to_uint256.cairo
+++ b/tests/test_ints_to_uint256.cairo
@@ -35,6 +35,12 @@ func test_covert_1{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() -> () {
 }
 
 @view
+func setup_covert_random{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() -> () {
+    %{ given(rand_int = strategy.felts()) %}
+    return ();
+}
+
+@view
 func test_covert_random{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(rand_int: felt) -> () {
     alloc_locals;
     %{

--- a/tests/test_to_big_endian.cairo
+++ b/tests/test_to_big_endian.cairo
@@ -52,6 +52,12 @@ func test_swap_endianness_full_word{range_check_ptr, bitwise_ptr: BitwiseBuiltin
 }
 
 @view
+func setup_swap_endianness_small_words{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}() -> () {
+    %{ given(i = strategy.felts()) %}
+    return ();
+}
+
+@view
 func test_swap_endianness_small_words{range_check_ptr, bitwise_ptr: BitwiseBuiltin*}(i: felt) -> (
     ) {
     helper_test_swap_endianness_small_words(8);


### PR DESCRIPTION
* Replace the use of `pow` with the standard pow function in cairo-lang
  repo
* Replace pow computations with constants where applicable

* This PR improves the resources used for `prove_account` by ~50%
Before:
steps=389198, memory_holes=30887 pedersen_builtin=21 range_check_builtin=6970
After:
steps=147619, memory_holes=32442 pedersen_builtin=21 range_check_builtin=7495