### PR TITLE
Feat/multi append

### DIFF
--- a/src/FactsRegistry.cairo
+++ b/src/FactsRegistry.cairo
@@ -233,6 +233,8 @@ func prove_account{
     let (local headers_store_addr) = _l1_headers_store_addr.read();
 
     // Root hash for `mmr_pos` must have been written to storage before.
+    // @notice `mmr_pos` is the tree size at the time of inclusion of the
+    // last element within the proof.
     let (mmr_root) = IL1HeadersStore.get_tree_size_to_root(
         contract_address=headers_store_addr, tree_size=mmr_pos
     );

--- a/src/FactsRegistry.cairo
+++ b/src/FactsRegistry.cairo
@@ -30,8 +30,18 @@ from lib.swap_endianness import swap_endianness_64
 @contract_interface
 namespace IL1HeadersStore {
     func call_mmr_verify_proof(
-        index: felt, value: felt, proof_len: felt, proof: felt*, peaks_len: felt, peaks: felt*
+        index: felt,
+        value: felt,
+        proof_len: felt,
+        proof: felt*,
+        peaks_len: felt,
+        peaks: felt*,
+        pos: felt,
+        root: felt,
     ) {
+    }
+
+    func get_tree_size_to_root(tree_size: felt) -> (res: felt) {
     }
 }
 
@@ -181,6 +191,7 @@ func constructor{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
 // @param block_header_rlp_len: The length of the `block_header_rlp` array, in words.
 // @param block_header_rlp: An array that contains the RLP-encoded block header.
 // @param block_header_rlp_bytes_len: The length of the RLP-encoded block header, in bytes.
+// @param mmr_pos The MMR pos (i.e., tree size) for the proof.
 //
 @external
 func prove_account{
@@ -204,6 +215,7 @@ func prove_account{
     block_header_rlp_len: felt,
     block_header_rlp: felt*,
     block_header_rlp_bytes_len: felt,
+    mmr_pos: felt,
 ) {
     alloc_locals;
     let (local account_raw) = alloc();
@@ -220,6 +232,12 @@ func prove_account{
     local path: IntsSequence = IntsSequence(path_raw, 4, 32);
     let (local headers_store_addr) = _l1_headers_store_addr.read();
 
+    // Root hash for `mmr_pos` must have been written to storage before.
+    let (mmr_root) = IL1HeadersStore.get_tree_size_to_root(
+        contract_address=headers_store_addr, tree_size=mmr_pos
+    );
+    assert_not_zero(mmr_root);
+
     IL1HeadersStore.call_mmr_verify_proof(
         contract_address=headers_store_addr,
         index=block_proof_leaf_index,
@@ -228,6 +246,8 @@ func prove_account{
         proof=block_proof,
         peaks_len=mmr_peaks_len,
         peaks=mmr_peaks,
+        pos=mmr_pos,
+        root=mmr_root,
     );
     let (pedersen_hash) = hash_felts{hash_ptr=pedersen_ptr}(
         data=block_header_rlp, length=block_header_rlp_len

--- a/src/L1HeadersStore.cairo
+++ b/src/L1HeadersStore.cairo
@@ -319,6 +319,7 @@ func process_till_block{
     assert_not_zero(mmr_root);
 
     // Verify the reference block proof and check its parent block
+    // We ensure that the first block header (the most recent) has its reference block in the MMR.
     validate_parent_block_and_proof_integrity(
         reference_proof_leaf_index,
         reference_proof_leaf_value,
@@ -349,7 +350,7 @@ func process_till_block{
         pedersen_hash,
     );
 
-    // Process the remaining blocks and recursively update the MMR tree.
+    // Process the remaining blocks (consecutive parents) and recursively update the MMR tree.
     let (elems_len: felt) = process_till_block_rec(
         block_headers_lens_bytes_len,
         block_headers_lens_bytes,
@@ -366,6 +367,7 @@ func process_till_block{
 
     let (mmr_last_pos) = _mmr_last_pos.read();
     let (mmr_last_root) = _mmr_root.read();
+    // Batch appends to the MMR tree.
     let (new_pos, new_root) = mmr_multi_append(
         elems_len=elems_len,
         elems=elems,

--- a/src/L1HeadersStore.cairo
+++ b/src/L1HeadersStore.cairo
@@ -30,12 +30,18 @@ func accumulator_update(
     keccak_hash_word_2: felt,
     keccak_hash_word_3: felt,
     keccak_hash_word_4: felt,
+    update_id: felt,
 ) {
 }
 
 // Temporary auth var for authenticating mocked L1 handlers.
 @storage_var
 func _l1_messages_origin() -> (res: felt) {
+}
+
+// Keeps count of the accumulator updates.
+@storage_var
+func _latest_accumulator_update_id() -> (res: felt) {
 }
 
 // Stores the latest commited L1 block.
@@ -66,6 +72,14 @@ func get_latest_commitments_l1_block{
     syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
 }() -> (res: felt) {
     return _commitments_latest_l1_block.read();
+}
+
+// Returns the latest accumulator update id.
+@view
+func get_latest_accumulator_update_id{
+    syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr
+}() -> (res: felt) {
+    return _latest_accumulator_update_id.read();
 }
 
 @constructor
@@ -511,8 +525,11 @@ func update_mmr{
     local word_3 = keccak_hash[2];
     local word_4 = keccak_hash[3];
 
+    let (local update_id) = _latest_accumulator_update_id.read();
+    _latest_accumulator_update_id.write(update_id + 1);
+
     // Emit the update event
-    accumulator_update.emit(pedersen_hash, processed_block_number, word_1, word_2, word_3, word_4);
+    accumulator_update.emit(pedersen_hash, processed_block_number, word_1, word_2, word_3, word_4, update_id);
     return ();
 }
 

--- a/src/L1HeadersStore.cairo
+++ b/src/L1HeadersStore.cairo
@@ -6,6 +6,7 @@ from starkware.cairo.common.cairo_builtins import BitwiseBuiltin
 from starkware.starknet.common.syscalls import get_caller_address
 from starkware.cairo.common.alloc import alloc
 from starkware.cairo.common.math_cmp import is_le
+from starkware.cairo.common.math import assert_not_zero
 
 from starkware.cairo.common.cairo_keccak.keccak import finalize_keccak
 
@@ -15,10 +16,10 @@ from lib.blockheader_rlp_extractor import decode_parent_hash, decode_block_numbe
 from lib.bitset import bitset_get
 from lib.swap_endianness import swap_endianness_64
 from starkware.cairo.common.hash_state import hash_felts
-from cairo_mmr.src.mmr import (
+from cairo_mmr.src.stateless_mmr import (
     append as mmr_append,
+    multi_append as mmr_multi_append,
     verify_proof as mmr_verify_proof,
-    get_last_pos as mmr_get_last_pos,
 )
 
 @event
@@ -31,6 +32,21 @@ func accumulator_update(
     keccak_hash_word_4: felt,
     update_id: felt,
 ) {
+}
+
+// MMR saved root hash.
+@storage_var
+func _mmr_root() -> (res: felt) {
+}
+
+// MMR last saved tree size (last position).
+@storage_var
+func _mmr_last_pos() -> (res: felt) {
+}
+
+// tree_size -> saved root hash.
+@storage_var
+func _tree_size_to_root(tree_size: felt) -> (res: felt) {
 }
 
 // Temporary auth var for authenticating mocked L1 handlers.
@@ -56,6 +72,31 @@ func _commitments_block_parent_hash(block_number: felt) -> (res: Keccak256Hash) 
 //###################################################
 //                   VIEW FUNCTIONS
 //###################################################
+
+// Returns the last saved MMR root.
+@view
+func get_mmr_root{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    res: felt
+) {
+    return _mmr_root.read();
+}
+
+// Returns the last saved MMR position (tree size).
+@view
+func get_mmr_last_pos{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    res: felt
+) {
+    return _mmr_last_pos.read();
+}
+
+// Returns the root related to a specific tree size (if any).
+// @notice The tree size must have been previously written to contract storage.
+@view
+func get_tree_size_to_root{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    tree_size: felt
+) -> (res: felt) {
+    return _tree_size_to_root.read(tree_size);
+}
 
 // Returns the Keccak hash of a given block number (if known).
 @view
@@ -166,6 +207,9 @@ func process_block{
 ) {
     alloc_locals;
 
+    let (mmr_last_pos) = _mmr_last_pos.read();
+    let (mmr_last_root) = _mmr_root.read();
+
     validate_parent_block_and_proof_integrity(
         reference_proof_leaf_index,
         reference_proof_leaf_value,
@@ -179,10 +223,18 @@ func process_block{
         block_header_rlp_bytes_len,
         block_header_rlp_len,
         block_header_rlp,
+        mmr_last_pos,
+        mmr_last_root,
     );
 
     update_mmr(
-        block_header_rlp_bytes_len, block_header_rlp_len, block_header_rlp, mmr_peaks_len, mmr_peaks
+        block_header_rlp_bytes_len,
+        block_header_rlp_len,
+        block_header_rlp,
+        mmr_peaks_len,
+        mmr_peaks,
+        mmr_last_pos,
+        mmr_last_root,
     );
     return ();
 }
@@ -222,8 +274,16 @@ func process_block_from_message{
         child_block_parent_hash, block_header_rlp_bytes_len, block_header_rlp_len, block_header_rlp
     );
 
+    let (mmr_last_pos) = _mmr_last_pos.read();
+    let (mmr_last_root) = _mmr_root.read();
     update_mmr(
-        block_header_rlp_bytes_len, block_header_rlp_len, block_header_rlp, mmr_peaks_len, mmr_peaks
+        block_header_rlp_bytes_len,
+        block_header_rlp_len,
+        block_header_rlp,
+        mmr_peaks_len,
+        mmr_peaks,
+        mmr_last_pos,
+        mmr_last_root,
     );
     return ();
 }
@@ -247,18 +307,16 @@ func process_till_block{
     block_headers_lens_words: felt*,
     block_headers_concat_len: felt,
     block_headers_concat: felt*,
-    mmr_peaks_lens_len: felt,
-    mmr_peaks_lens: felt*,
-    mmr_peaks_concat_len: felt,
-    mmr_peaks_concat: felt*,
+    mmr_peaks_len: felt,
+    mmr_peaks: felt*,
+    mmr_pos: felt,
 ) {
     alloc_locals;
     assert block_headers_lens_bytes_len = block_headers_lens_words_len;
 
-    let (local current_peaks: felt*) = alloc();
-    let (local updated_peaks_offset) = slice_arr(
-        0, mmr_peaks_lens[0], mmr_peaks_concat, mmr_peaks_concat_len, current_peaks, 0, 0
-    );
+    // Root hash for `mmr_pos` must have been written to storage before.
+    let (mmr_root) = _tree_size_to_root.read(mmr_pos);
+    assert_not_zero(mmr_root);
 
     // Verify the reference block proof and check its parent block
     validate_parent_block_and_proof_integrity(
@@ -266,56 +324,61 @@ func process_till_block{
         reference_proof_leaf_value,
         reference_proof_len,
         reference_proof,
-        mmr_peaks_lens[0],
-        current_peaks,
+        mmr_peaks_len,
+        mmr_peaks,
         reference_header_rlp_bytes_len,
         reference_header_rlp_len,
         reference_header_rlp,
         block_headers_lens_bytes[0],
         block_headers_lens_words[0],
         block_headers_concat,
+        mmr_pos,
+        mmr_root,
     );
 
-    // Add the first block
-    update_mmr(
+    // Add the first block.
+    let (pedersen_hash) = hash_felts{hash_ptr=pedersen_ptr}(
+        data=block_headers_concat, length=block_headers_lens_words[0]
+    );
+    let (elems: felt*) = alloc();
+    let (new_elems_len) = add_mmr_update_element(0, elems, pedersen_hash);
+    emit_mmr_update_event(
         block_headers_lens_bytes[0],
         block_headers_lens_words[0],
         block_headers_concat,
-        mmr_peaks_lens[0],
-        current_peaks,
+        pedersen_hash,
     );
 
     // Process the remaining blocks and recursively update the MMR tree.
-    process_till_block_rec(
+    let (elems_len: felt) = process_till_block_rec(
         block_headers_lens_bytes_len,
         block_headers_lens_bytes,
         block_headers_lens_words_len,
         block_headers_lens_words,
         block_headers_concat_len,
         block_headers_concat,
-        mmr_peaks_lens_len,
-        mmr_peaks_lens,
-        mmr_peaks_concat_len,
-        mmr_peaks_concat,
         0,
         0,
         0,
-        updated_peaks_offset,
+        new_elems_len,
+        elems,
     );
-    return ();
-}
 
-//
-// @dev This function gets the last position in the MMR tree.
-// @notice This function calls the `mmr_get_last_pos` function to get the last position in the MMR tree.
-// @return The last position in the MMR tree.
-//
-@external
-func get_mmr_last_pos{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
-    res: felt
-) {
-    let (last_pos) = mmr_get_last_pos();
-    return (res=last_pos);
+    let (mmr_last_pos) = _mmr_last_pos.read();
+    let (mmr_last_root) = _mmr_root.read();
+    let (new_pos, new_root) = mmr_multi_append(
+        elems_len=elems_len,
+        elems=elems,
+        peaks_len=mmr_peaks_len,
+        peaks=mmr_peaks,
+        last_pos=mmr_last_pos,
+        last_root=mmr_last_root,
+    );
+    // Update contract storage
+    _mmr_last_pos.write(new_pos);
+    _mmr_root.write(new_root);
+    _tree_size_to_root.write(new_pos, new_root);
+    return ();
 }
 
 //
@@ -327,12 +390,21 @@ func get_mmr_last_pos{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_chec
 // @param proof The array containing the proof.
 // @param peaks_len The length of the peaks array in the proof.
 // @param peaks The array containing the peaks in the proof.
+// @param pos The MMR last pos for this proof.
+// @param root The MMR root for this proof.
 //
 @external
 func call_mmr_verify_proof{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
-    index: felt, value: felt, proof_len: felt, proof: felt*, peaks_len: felt, peaks: felt*
+    index: felt,
+    value: felt,
+    proof_len: felt,
+    proof: felt*,
+    peaks_len: felt,
+    peaks: felt*,
+    pos: felt,
+    root: felt,
 ) {
-    mmr_verify_proof(index, value, proof_len, proof, peaks_len, peaks);
+    mmr_verify_proof(index, value, proof_len, proof, peaks_len, peaks, pos, root);
     return ();
 }
 
@@ -401,6 +473,8 @@ func validate_parent_block{
 // @param block_header_rlp_bytes_len The length of the block header RLP bytes array.
 // @param block_header_rlp_len The length of the block header RLP array.
 // @param block_header_rlp The array containing the block header RLP bytes.
+// @param mmr_pos The MMR pos (i.e., tree size) for the proof.
+// @param mmr_root The MMR root of the given tree size.
 //
 func validate_parent_block_and_proof_integrity{
     pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, bitwise_ptr: BitwiseBuiltin*, range_check_ptr
@@ -417,6 +491,8 @@ func validate_parent_block_and_proof_integrity{
     block_header_rlp_bytes_len: felt,
     block_header_rlp_len: felt,
     block_header_rlp: felt*,
+    mmr_pos: felt,
+    mmr_root: felt,
 ) {
     alloc_locals;
 
@@ -427,6 +503,8 @@ func validate_parent_block_and_proof_integrity{
         proof=reference_proof,
         peaks_len=mmr_peaks_len,
         peaks=mmr_peaks,
+        pos=mmr_pos,
+        root=mmr_root,
     );
 
     local rlp: IntsSequence = IntsSequence(
@@ -445,31 +523,23 @@ func validate_parent_block_and_proof_integrity{
     return ();
 }
 
-//
-// @dev This function updates the MMR tree with a new block.
-// @notice This function computes the Pedersen hash of the given block and appends it to the MMR tree.
-// It then emits the `AccumulatorUpdate` event with the processed block number, the Pedersen hash, and the Keccak256 hash of the block.
-// @param block_header_rlp_bytes_len The length of the block header RLP in bytes.
-// @param block_header_rlp_len The length of the block header RLP in felts.
-// @param block_header_rlp The block header RLP.
-// @param mmr_peaks_len The length of the MMR peaks array.
-// @param mmr_peaks The array of MMR peaks.
-//
-func update_mmr{
+func add_mmr_update_element{
+    pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, bitwise_ptr: BitwiseBuiltin*, range_check_ptr
+}(elems_len: felt, elems: felt*, elem: felt) -> (new_elems_len: felt) {
+    assert elems[elems_len] = elem;
+    return (new_elems_len=elems_len + 1);
+}
+
+func emit_mmr_update_event{
     pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, bitwise_ptr: BitwiseBuiltin*, range_check_ptr
 }(
     block_header_rlp_bytes_len: felt,
     block_header_rlp_len: felt,
     block_header_rlp: felt*,
-    mmr_peaks_len: felt,
-    mmr_peaks: felt*,
+    pedersen_hash: felt,
 ) {
     alloc_locals;
 
-    let (pedersen_hash) = hash_felts{hash_ptr=pedersen_ptr}(
-        data=block_header_rlp, length=block_header_rlp_len
-    );
-    mmr_append(elem=pedersen_hash, peaks_len=mmr_peaks_len, peaks=mmr_peaks);
     let (local keccak_ptr: felt*) = alloc();
     let keccak_ptr_start = keccak_ptr;
 
@@ -487,10 +557,59 @@ func update_mmr{
 
     let (local update_id) = _latest_accumulator_update_id.read();
     _latest_accumulator_update_id.write(update_id + 1);
-
     // Emit the update event
-    accumulator_update.emit(pedersen_hash, processed_block_number, word_1, word_2, word_3, word_4, update_id);
+    accumulator_update.emit(
+        pedersen_hash, processed_block_number, word_1, word_2, word_3, word_4, update_id
+    );
     return ();
+}
+
+//
+// @dev This function updates the MMR tree with a new block.
+// @notice This function computes the Pedersen hash of the given block and appends it to the MMR tree.
+// It then emits the `AccumulatorUpdate` event with the processed block number, the Pedersen hash, and the Keccak256 hash of the block.
+// @param block_header_rlp_bytes_len The length of the block header RLP in bytes.
+// @param block_header_rlp_len The length of the block header RLP in felts.
+// @param block_header_rlp The block header RLP.
+// @param mmr_peaks_len The length of the MMR peaks array.
+// @param mmr_peaks The array of MMR peaks.
+// @param mmr_last_pos The MMR last pos (i.e., tree size).
+// @param mmr_last_root The MMR last root.
+//
+func update_mmr{
+    pedersen_ptr: HashBuiltin*, syscall_ptr: felt*, bitwise_ptr: BitwiseBuiltin*, range_check_ptr
+}(
+    block_header_rlp_bytes_len: felt,
+    block_header_rlp_len: felt,
+    block_header_rlp: felt*,
+    mmr_peaks_len: felt,
+    mmr_peaks: felt*,
+    mmr_last_pos: felt,
+    mmr_last_root: felt,
+) -> (last_pos: felt, last_root: felt) {
+    alloc_locals;
+
+    let (pedersen_hash) = hash_felts{hash_ptr=pedersen_ptr}(
+        data=block_header_rlp, length=block_header_rlp_len
+    );
+    let (new_pos, new_root) = mmr_append(
+        elem=pedersen_hash,
+        peaks_len=mmr_peaks_len,
+        peaks=mmr_peaks,
+        last_pos=mmr_last_pos,
+        last_root=mmr_last_root,
+    );
+
+    emit_mmr_update_event(
+        block_header_rlp_bytes_len, block_header_rlp_len, block_header_rlp, pedersen_hash
+    );
+    // Update contract storage
+
+    _mmr_last_pos.write(new_pos);
+    _mmr_root.write(new_root);
+    _tree_size_to_root.write(new_pos, new_root);
+
+    return (last_pos=new_pos, last_root=new_root);
 }
 
 //
@@ -505,19 +624,16 @@ func process_till_block_rec{
     block_headers_lens_words: felt*,
     block_headers_concat_len: felt,
     block_headers_concat: felt*,
-    mmr_peaks_lens_len: felt,
-    mmr_peaks_lens: felt*,
-    mmr_peaks_concat_len: felt,
-    mmr_peaks_concat: felt*,
     header_index: felt,
     child_offset: felt,
     parent_offset: felt,
-    peaks_offset: felt,
-) {
+    elems_len: felt,
+    elems: felt*,
+) -> (new_elems_len: felt) {
     alloc_locals;
 
     if (header_index == block_headers_lens_bytes_len - 1) {
-        return ();
+        return (new_elems_len=elems_len);
     }
 
     let (local current_child: felt*) = alloc();
@@ -551,22 +667,15 @@ func process_till_block_rec{
         parent_header_rlp=current_parent,
     );
 
-    let (local current_peaks: felt*) = alloc();
-    let (local updated_peaks_offset) = slice_arr(
-        peaks_offset,
-        mmr_peaks_lens[peaks_offset],
-        mmr_peaks_concat,
-        mmr_peaks_concat_len,
-        current_peaks,
-        0,
-        0,
+    let (pedersen_hash) = hash_felts{hash_ptr=pedersen_ptr}(
+        data=current_parent, length=block_headers_lens_words[header_index + 1]
     );
-    update_mmr(
+    let (new_elems_len) = add_mmr_update_element(elems_len, elems, pedersen_hash);
+    emit_mmr_update_event(
         block_headers_lens_bytes[header_index + 1],
         block_headers_lens_words[header_index + 1],
         current_parent,
-        mmr_peaks_lens[peaks_offset],
-        current_peaks,
+        pedersen_hash,
     );
 
     return process_till_block_rec(
@@ -576,14 +685,11 @@ func process_till_block_rec{
         block_headers_lens_words,
         block_headers_concat_len,
         block_headers_concat,
-        mmr_peaks_lens_len,
-        mmr_peaks_lens,
-        mmr_peaks_concat_len,
-        mmr_peaks_concat,
         header_index + 1,
         updated_child_offset,
         updated_parent_offset,
-        updated_peaks_offset,
+        new_elems_len,
+        elems,
     );
 }
 

--- a/tests/contracts/test_l1_facts_registry.cairo
+++ b/tests/contracts/test_l1_facts_registry.cairo
@@ -24,6 +24,11 @@ namespace L1HeadersStore {
     ) {
     }
 
+    // Returns the last saved MMR root.
+    func get_mmr_root() -> (res: felt) {
+    }
+
+    // Returns the last saved MMR position (tree size).
     func get_mmr_last_pos() -> (res: felt) {
     }
 }
@@ -49,6 +54,7 @@ namespace FactsRegistry {
         block_header_rlp_len: felt,
         block_header_rlp: felt*,
         block_header_rlp_bytes_len: felt,
+        mmr_pos: felt,
     ) {
     }
 
@@ -245,6 +251,7 @@ func test_prove_account{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_ch
         segments.write_arg(ids.proofs_concat, flat_proof)
     %}
     local account: Address = Address(account_word_1, account_word_2, account_word_3);
+    let (mmr_last_pos) = L1HeadersStore.get_mmr_last_pos(contract_address=l1_headers_store);
     FactsRegistry.prove_account(
         contract_address=facts_registry,
         options_set=options_set,
@@ -265,6 +272,7 @@ func test_prove_account{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_ch
         block_header_rlp_len=block_header_rlp_len,
         block_header_rlp=block_header_rlp,
         block_header_rlp_bytes_len=block_header_rlp_bytes_len,
+        mmr_pos=mmr_last_pos,
     );
 
     local account_160;
@@ -359,6 +367,7 @@ func test_get_storage{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_chec
         segments.write_arg(ids.proofs_concat, flat_proof)
     %}
     local account: Address = Address(account_word_1, account_word_2, account_word_3);
+    let (mmr_last_pos) = L1HeadersStore.get_mmr_last_pos(contract_address=l1_headers_store);
     FactsRegistry.prove_account(
         contract_address=facts_registry,
         options_set=options_set,
@@ -379,6 +388,7 @@ func test_get_storage{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_chec
         block_header_rlp_len=block_header_rlp_len,
         block_header_rlp=block_header_rlp,
         block_header_rlp_bytes_len=block_header_rlp_bytes_len,
+        mmr_pos=mmr_last_pos,
     );
     local slot_word1;
     local slot_word2;
@@ -500,6 +510,7 @@ func test_get_storage_uint{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range
         segments.write_arg(ids.proofs_concat, flat_proof)
     %}
     local account: Address = Address(account_word_1, account_word_2, account_word_3);
+    let (mmr_last_pos) = L1HeadersStore.get_mmr_last_pos(contract_address=l1_headers_store);
     FactsRegistry.prove_account(
         contract_address=facts_registry,
         options_set=options_set,
@@ -520,6 +531,7 @@ func test_get_storage_uint{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range
         block_header_rlp_len=block_header_rlp_len,
         block_header_rlp=block_header_rlp,
         block_header_rlp_bytes_len=block_header_rlp_bytes_len,
+        mmr_pos=mmr_last_pos,
     );
     local slot_word1;
     local slot_word2;

--- a/tests/contracts/test_l1_headers_store.cairo
+++ b/tests/contracts/test_l1_headers_store.cairo
@@ -62,14 +62,10 @@ namespace L1HeadersStore {
         block_headers_lens_words: felt*,
         block_headers_concat_len: felt,
         block_headers_concat: felt*,
-        mmr_peaks_lens_len: felt,
-        mmr_peaks_lens: felt*,
-        mmr_peaks_concat_len: felt,
-        mmr_peaks_concat: felt*,
+        mmr_peaks_len: felt,
+        mmr_peaks: felt*,
+        mmr_pos: felt,
     ) {
-    }
-
-    func get_mmr_last_pos() -> (res: felt) {
     }
 }
 
@@ -483,10 +479,9 @@ func test_process_till_block{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, ran
         block_headers_lens_words=block_headers_lens_words,
         block_headers_concat_len=block_headers_concat_len,
         block_headers_concat=block_headers_concat,
-        mmr_peaks_lens_len=3,
-        mmr_peaks_lens=mmr_peaks_lens,
-        mmr_peaks_concat_len=4,
-        mmr_peaks_concat=mmr_peaks_concat,
+        mmr_peaks_len=1,
+        mmr_peaks=mmr_peaks,
+        mmr_pos=1,
     );
     return ();
 }

--- a/tests/contracts/test_l2_state_roots.cairo
+++ b/tests/contracts/test_l2_state_roots.cairo
@@ -25,6 +25,11 @@ namespace L1HeadersStore {
     ) {
     }
 
+    // Returns the last saved MMR root.
+    func get_mmr_root() -> (res: felt) {
+    }
+
+    // Returns the last saved MMR position (tree size).
     func get_mmr_last_pos() -> (res: felt) {
     }
 }
@@ -50,6 +55,7 @@ namespace L2StateRootsProcessor {
         receipt_inclusion_proof_sizes_words: felt*,
         receipt_inclusion_proof_concat_len: felt,
         receipt_inclusion_proof_concat: felt*,
+        mmr_pos: felt,
     ) {
     }
 }
@@ -263,6 +269,7 @@ func test_process_state_root{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, ran
     %}
 
     let (local block_proof: felt*) = alloc();
+    let (mmr_last_pos) = L1HeadersStore.get_mmr_last_pos(contract_address=l1_headers_store);
     L2StateRootsProcessor.process_state_root(
         contract_address=state_roots_processor,
         l1_inclusion_header_leaf_index=1,
@@ -283,6 +290,7 @@ func test_process_state_root{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, ran
         receipt_inclusion_proof_sizes_words=receipt_proof_sizes_words,
         receipt_inclusion_proof_concat_len=receipt_proof_concat_len,
         receipt_inclusion_proof_concat=receipt_proof_concat,
+        mmr_pos=mmr_last_pos,
     );
     return ();
 }


### PR DESCRIPTION
- Use `multi_append` for `process_till_block`
- No peaks[][] required anymore